### PR TITLE
Update Cypress tests and API calls to use deployed API URL

### DIFF
--- a/cypress/e2e/aboutpage_spec.cy.js
+++ b/cypress/e2e/aboutpage_spec.cy.js
@@ -1,6 +1,6 @@
 describe('about page spec', () => {
   beforeEach(() => {
-    cy.intercept('GET', 'https://lucifer-quotes.vercel.app/api/quotes/10', {
+    cy.intercept('GET', 'https://luciverse-api.onrender.com/api/quotes', {
       statusCode: 200,
       fixture: 'quotes'
     })

--- a/cypress/e2e/errors_spec.cy.js
+++ b/cypress/e2e/errors_spec.cy.js
@@ -18,7 +18,7 @@ describe('Errors spec', () => {
   })
 
   it('should display error message for wild card path', () => {
-    cy.intercept("GET", "https://lucifer-quotes.vercel.app/api/quotes/10", {
+    cy.intercept("GET", "https://luciverse-api.onrender.com/api/quotes", {
       statusCode: 200,
       fixture: "quotes"
     });

--- a/cypress/e2e/hompage_spec.cy.js
+++ b/cypress/e2e/hompage_spec.cy.js
@@ -1,6 +1,6 @@
 describe('homepage spec', () => {
   beforeEach(() => {
-    cy.intercept('GET', 'https://lucifer-quotes.vercel.app/api/quotes/10', {
+    cy.intercept('GET', 'https://luciverse-api.onrender.com/api/quotes', {
       statusCode: 200,
       fixture: 'quotes'
     })

--- a/src/App/App.js
+++ b/src/App/App.js
@@ -37,7 +37,6 @@ class App extends Component {
   }
 
   render() {
-    console.log(this.state.quotes);
     return (
       <>
         <Nav />

--- a/src/apiCalls.js
+++ b/src/apiCalls.js
@@ -1,5 +1,5 @@
 export function fetchQuotes() {
-   return fetch("http://localhost:8000/api/quotes")
+   return fetch("https://luciverse-api.onrender.com/api/quotes")
         .then(res => {
             if (!res.ok) {
                 throw new Error("Oops! We seem to be having some technical issues, please try again later!");


### PR DESCRIPTION
# Pull Request

## Description
Update Cypress tests and API calls to use the deployed Luciverse API URL.

## Changes
- Updated all frontend API calls in tests to point to the deployed API.
- Ensures end-to-end tests work with live backend.