### PR TITLE
Enable adding quotes via POST to deployed API

### DIFF
--- a/cypress/e2e/aboutpage_spec.cy.js
+++ b/cypress/e2e/aboutpage_spec.cy.js
@@ -1,32 +1,57 @@
-describe('about page spec', () => {
+describe('About Page Spec', () => {
   beforeEach(() => {
     cy.intercept('GET', 'https://luciverse-api.onrender.com/api/quotes', {
       statusCode: 200,
-      fixture: 'quotes'
-    })
-    cy.visit('http://localhost:3000/About')
+      fixture: 'quotes',
+    });
   });
 
-  it('Should display the navbar with a logo the takes user back to homepage', () => {
-    cy.get('nav').find('.about-container').contains('h2', 'About')
-      .get('nav').find('.logo-container').contains('h1', 'LuciVerse')
-      .click()
-      .url().should('eq', 'http://localhost:3000/')
-  })
+  it('Should display the navbar with a logo that takes the user back to homepage', () => {
+    cy.visit('https://luciverse-qjxr-rm92ririg-hjawad22s-projects.vercel.app/')
+      .get('nav')
+        .find('.logo-container')
+        .contains('h1', 'LuciVerse')
+      .get('nav')
+        .find('.about-container')
+        .contains('h2', 'About')
+        .click()
+      .url()
+        .should('eq', 'https://luciverse-qjxr-rm92ririg-hjawad22s-projects.vercel.app/About');
+  });
 
-  it('Should display title and Tv show description', () => {
-    cy.get('.about-header').contains('About The Show')
-      .get('.about-pg-container > :nth-child(2)').contains('"Lucifer" is a television series that originally premiered on Fox and later moved to Netflix. It is based on the DC Comics character created by Neil Gaiman, Sam Kieth, and Mike Dringenberg. The show follows Lucifer Morningstar, portrayed by Tom Ellis, who decides to abandon his throne in Hell and moves to Los Angeles. He becomes the owner of a nightclub called Lux and starts assisting the LAPD in solving various crimes.')
-      .get('.about-pg-container > :nth-child(3)').contains('The series combines elements of crime procedural, supernatural, and drama genres. It explores themes of redemption, morality, and the complexity of human nature. Over the seasons, "Lucifer" has gained a dedicated fanbase and has been praised for its charismatic performances, witty dialogue, and intriguing storylines.')
-      .get('.about-pg-container > :nth-child(4)').contains('The show has received critical acclaim and has been applauded for its unique blend of genres and compelling character development. It has also sparked discussions and fan theories due to its exploration of theological and philosophical concepts in a contemporary setting.')
-      .get('.about-pg-container > :nth-child(5)').contains('With its engaging storytelling and charismatic cast, "Lucifer" has become a popular series enjoyed by fans around the world. It has garnered a strong following and has been renewed for multiple seasons, captivating viewers with its mix of supernatural elements and compelling narratives.')
-  })
+  it('Should display title and TV show description', () => {
+    cy.visit('https://luciverse-qjxr-rm92ririg-hjawad22s-projects.vercel.app/About');
+
+    cy.get('.about-pg-container')
+      .find('.about-header')
+      .contains('About The Show');
+
+    cy.get('.about-pg-container > :nth-child(2)')
+      .contains(
+        '"Lucifer" is a television series that originally premiered on Fox and later moved to Netflix. It is based on the DC Comics character created by Neil Gaiman, Sam Kieth, and Mike Dringenberg. The show follows Lucifer Morningstar, portrayed by Tom Ellis, who decides to abandon his throne in Hell and moves to Los Angeles. He becomes the owner of a nightclub called Lux and starts assisting the LAPD in solving various crimes.'
+      );
+
+    cy.get('.about-pg-container > :nth-child(3)')
+      .contains(
+        'The series combines elements of crime procedural, supernatural, and drama genres. It explores themes of redemption, morality, and the complexity of human nature. Over the seasons, "Lucifer" has gained a dedicated fanbase and has been praised for its charismatic performances, witty dialogue, and intriguing storylines.'
+      );
+
+    cy.get('.about-pg-container > :nth-child(4)')
+      .contains(
+        'The show has received critical acclaim and has been applauded for its unique blend of genres and compelling character development. It has also sparked discussions and fan theories due to its exploration of theological and philosophical concepts in a contemporary setting.'
+      );
+
+    cy.get('.about-pg-container > :nth-child(5)')
+      .contains(
+        'With its engaging storytelling and charismatic cast, "Lucifer" has become a popular series enjoyed by fans around the world. It has garnered a strong following and has been renewed for multiple seasons, captivating viewers with its mix of supernatural elements and compelling narratives.'
+      );
+  });
 
   it('Should have a button that takes user back to homepage', () => {
-    cy.get('.back-button')
+    cy.visit('https://luciverse-qjxr-rm92ririg-hjawad22s-projects.vercel.app/About')
+      .get('.back-button')
       .click()
-      .url().should('eq', 'http://localhost:3000/');
-  })
-
-
-})
+      .url()
+      .should('eq', 'https://luciverse-qjxr-rm92ririg-hjawad22s-projects.vercel.app/');
+  });
+});

--- a/cypress/e2e/errors_spec.cy.js
+++ b/cypress/e2e/errors_spec.cy.js
@@ -1,46 +1,55 @@
-describe('Errors spec', () => {
-  it('should display error message for home page for client side error', () => {
-    cy.intercept("GET", "https://lucifer-quotes.vercel.app/api/quotes/10", {
+describe('Errors Spec', () => {
+  it('Should display error message for home page for client side error', () => {
+    cy.intercept('GET', 'https://luciverse-api.onrender.com/api/quotes', {
       statusCode: 404,
     });
-    cy.visit('http://localhost:3000')
-      .get('.error').contains('Oops! We seem to be having some technical issues, please try again later!')
-      .get('.luci-img').should('be.visible')
-  })
 
-  it('should display error message for home page for server side error', () => {
-    cy.intercept("GET", "https://lucifer-quotes.vercel.app/api/quotes/10", {
+    cy.visit('https://luciverse-qjxr-rm92ririg-hjawad22s-projects.vercel.app/', {
+      failOnStatusCode: false,
+    })
+      .get('.error')
+      .contains('Oops! We seem to be having some technical issues, please try again later!')
+      .get('.luci-img')
+      .should('be.visible');
+  });
+
+  it('Should display error message for home page for server side error', () => {
+    cy.intercept('GET', 'https://luciverse-api.onrender.com/api/quotes', {
       statusCode: 500,
     });
-    cy.visit('http://localhost:3000')
-      .get('.error').contains('Oops! We seem to be having some technical issues, please try again later!')
-      .get('.luci-img').should('be.visible')
-  })
 
-  it('should display error message for wild card path', () => {
-    cy.intercept("GET", "https://luciverse-api.onrender.com/api/quotes", {
-      statusCode: 200,
-      fixture: "quotes"
-    });
-    cy.visit('http://localhost:3000/24')
-      .get('.error').contains('404 Page Not Found')
-      .get('.luci-img').should('be.visible')
+    cy.visit('https://luciverse-qjxr-rm92ririg-hjawad22s-projects.vercel.app/')
+      .get('.error')
+      .contains('Oops! We seem to be having some technical issues, please try again later!')
+      .get('.luci-img')
+      .should('be.visible');
+  });
+
+  it('Should display error message for wild card path', () => {
+    cy.visit('https://luciverse-qjxr-rm92ririg-hjawad22s-projects.vercel.app/does-not-exist')
+      .get('.error')
+      .contains('404 Page Not Found')
+      .get('.luci-img')
+      .should('be.visible')
       .get('.back-home-button')
       .click()
-      .url().should('eq', 'http://localhost:3000/');
+      .url()
+      .should('eq', 'https://luciverse-qjxr-rm92ririg-hjawad22s-projects.vercel.app/');
   });
 
-
-  it('should not add a quote when input fields are empty', () => {
-    cy.intercept("GET", "https://lucifer-quotes.vercel.app/api/quotes/10", {
+  it('Should not add a quote when input fields are empty', () => {
+    cy.intercept('GET', 'https://lucifer-quotes.vercel.app/api/quotes/10', {
       statusCode: 200,
-      fixture: "quotes"
+      fixture: 'quotes',
     });
-    cy.visit('http://localhost:3000')
-      .get('.add-button').click()
-    cy.get('.cards-container')
+
+    cy.visit('https://luciverse-qjxr-rm92ririg-hjawad22s-projects.vercel.app/')
+      .get('.add-button')
+      .click()
+      .get('.cards-container')
       .find('.card')
-      .should('have.length', 10);
-    cy.get('.error-message').contains('Please fill in all the required fields.')
+      .should('have.length', 11)
+      .get('.error-message')
+      .contains('Please fill in all the required fields.');
   });
-})
+});

--- a/cypress/e2e/hompage_spec.cy.js
+++ b/cypress/e2e/hompage_spec.cy.js
@@ -1,66 +1,102 @@
-describe('homepage spec', () => {
+describe('Homepage Spec', () => {
   beforeEach(() => {
     cy.intercept('GET', 'https://luciverse-api.onrender.com/api/quotes', {
       statusCode: 200,
-      fixture: 'quotes'
-    })
-    cy.visit('http://localhost:3000')
+      fixture: 'quotes',
+    });
+    cy.visit('https://luciverse-qjxr-rm92ririg-hjawad22s-projects.vercel.app/');
   });
 
   it('Should display the navbar with a logo and an about page link', () => {
-    cy.get('nav').find('.logo-container').contains('h1', 'LuciVerse')
-      .get('nav').find('.about-container').contains('h2', 'About')
-  })
+    cy.get('nav')
+      .find('.logo-container')
+      .contains('h1', 'LuciVerse')
+      .get('nav')
+      .find('.about-container')
+      .contains('h2', 'About');
+  });
 
   it('Should have a fixed nav when a user scrolls', () => {
     cy.scrollTo('bottom', { duration: 900 });
     cy.get('.nav-container').should('have.css', 'position', 'fixed');
   });
 
-
   it('Should have an about tab that takes user to the about page', () => {
-    cy.get('nav').find('.about-container').contains('h2', 'About')
+    cy.get('nav')
+      .find('.about-container')
+      .contains('h2', 'About')
       .click()
-      .url().should('eq', 'http://localhost:3000/About');
-  })
+      .url()
+      .should('eq', 'https://luciverse-qjxr-rm92ririg-hjawad22s-projects.vercel.app/About');
+  });
 
   it('Should display a hero image and a welcome message', () => {
     cy.get('.hero-image-container')
       .should('have.css', 'background-image')
-      .and('include', 'https://images.hdqwalls.com/wallpapers/lucifer-season-4-poster-ka.jpg')
-      .get('.hero-image-container').contains('Welcome To The LuciVerse')
-  })
+      .and(
+        'include',
+        'https://images.hdqwalls.com/wallpapers/lucifer-season-4-poster-ka.jpg'
+      )
+      .get('.hero-image-container')
+      .contains('Welcome To The LuciVerse');
+  });
 
-  it('should display TV show quotes', () => {
-    cy.get('.cards-container')
-      .find('.card')
-      .should('have.length', 10)
-      .get(':nth-child(1) > h3.card-text').contains("Take a swing...you'll have splinters in your stool.")
-      .get(':nth-child(1) > .author').contains('Lucifer Morningstar')
-      .get(':nth-child(10) > h3.card-text').contains('We might not always understand it, but God has a plan.')
-      .get(':nth-child(10) > .author').contains('Father Frank')
+  it('Should display TV show quotes', () => {
+    cy.get('.cards-container .card').should('have.length', 11);
+
+    cy.get('.cards-container .card')
+      .eq(0)
+      .within(() => {
+        cy.get('h3.card-text').should('contain', 'What is it that you truly want?');
+        cy.get('.author').should('contain', 'Lucifer');
+      });
+
+    cy.get('.cards-container .card')
+      .eq(9)
+      .within(() => {
+        cy.get('h3.card-text').should('contain', 'I always get what I want.');
+        cy.get('.author').should('contain', 'Lucifer');
+      });
+
+    cy.get('.cards-container .card')
+      .eq(10)
+      .within(() => {
+        cy.get('h3.card-text').should(
+          'contain',
+          'What is it about humans that makes them so interesting? I mean, you’re all weak, self-destructive, and yet… endlessly fascinating.'
+        );
+        cy.get('.author').should('contain', 'Lucifer');
+      });
   });
 
   it('Should display a form that lets user add a quote', () => {
-    cy.get('.form-container').contains('.form-text', "GOT A LUCIFIER QUOTE YOU DON'T SEE? ADD IT HERE, WE KNOW IT'S WHAT YOU TRULY DESIRE...")
-    .get('[placeholder="what is the quote?"]').type('Dear old dad!')
-    .get('[placeholder="who would say it?"]').type('Lucifier Morningstar')
-    .get('.add-button').click()
-    .get('.cards-container')
-    .find('.card')
-    .should('have.length', 11)
-    .get('.cards-container > :nth-child(11)').contains('Dear old dad!')
-    .get(':nth-child(11) > .author').contains('Lucifier Morningstar')
-  });
- 
-  it('should display error loading message', () => {
-    cy.intercept("GET", "https://lucifer-quotes.vercel.app/api/quotes/10", {
-      delay: 5000, 
-      statusCode: 200,
-      fixture: "quotes"
+    cy.get('.form-container').within(() => {
+      cy.contains(
+        '.form-text',
+        "GOT A LUCIFIER QUOTE YOU DON'T SEE? ADD IT HERE, WE KNOW IT'S WHAT YOU TRULY DESIRE..."
+      );
+      cy.get('[placeholder="what is the quote?"]').type('Dear old dad!');
+      cy.get('[placeholder="who would say it?"]').type('Lucifer');
+      cy.get('.add-button').click();
     });
-      cy.get('.loading-message') 
-      .should('be.visible');
+
+    cy.get('.cards-container .card').should('have.length', 12);
+
+    cy.get('.cards-container .card')
+      .last()
+      .within(() => {
+        cy.get('h3.card-text').should('contain.text', 'Dear old dad!');
+        cy.get('.author').should('contain.text', 'Lucifer');
+      });
   });
 
-})
+  it('Should display error loading message', () => {
+    cy.intercept('GET', 'https://luciverse-api.onrender.com/api/quotes', {
+      delay: 5000,
+      statusCode: 200,
+      fixture: 'quotes',
+    });
+
+    cy.get('.loading-message').should('be.visible');
+  });
+});

--- a/cypress/fixtures/quotes.json
+++ b/cypress/fixtures/quotes.json
@@ -1,42 +1,13 @@
 [
-  {
-  "quote": "Take a swing...you'll have splinters in your stool.",
-  "author": "Lucifer Morningstar"
-  },
-  {
-  "quote": "My life imploded because of you. My marriage, my Job, my snacks. I know you ate my pudding. It was labelled!",
-  "author": "Dan Espinoza"
-  },
-  {
-  "quote": "Immortality? Mm. Of course. Uh…you spell that with one or two \"m\"s? I always forget.",
-  "author": "Chloe Decker"
-  },
-  {
-  "quote": "I'm trying to say this from a constructive place. I can feel your negative vibrations from across the room, man.",
-  "author": "Dan Espinoza"
-  },
-  {
-  "quote": "The best thing to do is always to follow your greatest desire.",
-  "author": "Lucifer Morningstar"
-  },
-  {
-  "quote": "Well, that is a shame. 'Cause you and my backside used to get on very well.",
-  "author": "Lucifer Morningstar"
-  },
-  {
-  "quote": "I find that people make Los Angeles their home for one of two reasons. Either they're running from something, or looking for something.",
-  "author": "Linda Martin"
-  },
-  {
-  "quote": "People don't arrive broken. They start with passion and yearning till something comes along that disabuses them of those notions.",
-  "author": "Lucifer Morningstar"
-  },
-  {
-  "quote": "My name's Beatrice but everybody calls me Trixie.",
-  "author": "Trixie"
-  },
-  {
-  "quote": "We might not always understand it, but God has a plan.",
-  "author": "Father Frank"
-  }
-  ]
+  { "quote": "What is it that you truly want?", "character": "Lucifer" },
+  { "quote": "The world is full of sinners. Welcome to my life.", "character": "Lucifer" },
+  { "quote": "Evil is a point of view.", "character": "Lucifer" },
+  { "quote": "You have to deal with your past to move forward.", "character": "Chloe" },
+  { "quote": "I’m the devil, and I’m honest about it.", "character": "Lucifer" },
+  { "quote": "We all have choices to make.", "character": "Amenadiel" },
+  { "quote": "Sometimes chaos is necessary.", "character": "Maze" },
+  { "quote": "Life is complicated; embrace it.", "character": "Linda" },
+  { "quote": "Love can be deadly.", "character": "Chloe" },
+  { "quote": "I always get what I want.", "character": "Lucifer" },
+  { "quote": "What is it about humans that makes them so interesting? I mean, you’re all weak, self-destructive, and yet… endlessly fascinating.", "character": "Lucifer" }
+]

--- a/src/App/App.js
+++ b/src/App/App.js
@@ -1,7 +1,7 @@
 import "./App.css";
 import Nav from "../Nav/Nav";
 import { Component } from "react";
-import { fetchQuotes } from "../apiCalls";
+import { fetchQuotes, postQuote } from "../apiCalls";
 import { Route, Switch } from "react-router-dom/cjs/react-router-dom.min";
 import Quotes from "../Quotes/Quotes";
 import About from "../About/About";
@@ -32,9 +32,16 @@ class App extends Component {
       });
   };
 
-  addQuote = (newQuote) => {
-    this.setState({ quotes: [...this.state.quotes, newQuote] });
+  addQuote = (quoteText, characterName) => {
+    postQuote(quoteText, characterName)
+      .then(newQuote => {
+        this.setState(prevState => ({
+          quotes: [...prevState.quotes, newQuote]
+        }));
+      })
+      .catch(err => this.setState({ errorMessage: err.message }));
   }
+
 
   render() {
     return (

--- a/src/Form/Form.js
+++ b/src/Form/Form.js
@@ -16,17 +16,19 @@ class Form extends Component {
     handleChange = (event) => {
         this.setState({ [event.target.name]: event.target.value });
     }
-
-    submitQuote = (event) => {
+    
+ submitQuote = (event) => {
         event.preventDefault();
 
-        if (this.state.quote && this.state.character) {
-            this.setState({ error: '' })
-            const newQuote = {
-                id: Date.now(),
-                ...this.state
-            }
-            this.props.addQuote(newQuote);
+        const { quote, character } = this.state;
+
+        if (quote && character) {
+            this.setState({ error: '' });
+
+            // Call the addQuote function passed from App
+            this.props.addQuote(quote, character);
+
+            // Clear the input fields
             this.clearInputs();
         } else {
             this.setState({ error: 'Please fill in all the required fields.' });

--- a/src/apiCalls.js
+++ b/src/apiCalls.js
@@ -8,3 +8,18 @@ export function fetchQuotes() {
         });
 };
 
+export function postQuote(quote, character) {
+    return fetch("https://luciverse-api.onrender.com/api/quotes", {
+        method: "POST",
+        headers: {
+            "Content-Type": "application/json"
+        },
+        body: JSON.stringify({ quote, character })
+    })
+    .then(res => {
+        if (!res.ok) {
+            throw new Error("Failed to add quote. Please try again.");
+        }
+        return res.json();
+    });
+}


### PR DESCRIPTION
# Pull Request

## Overview
This PR enables users to add new quotes to the LuciVerse app by sending them to the deployed API. Previously, quotes could only be displayed and managed locally. Now, the frontend and backend are fully integrated to handle POST requests.

## Changes

### Frontend
- Updated the `Form` component to send the quote and character to the backend.
- `addQuote` in `App` now calls the API’s POST endpoint and updates the state once the quote is successfully added.

### API Calls
- `postQuote(quote, character)` handles POST requests separately for clarity.
